### PR TITLE
chore(sphere): Bump sphere-sdk and sphere-utils versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,8 +39,8 @@
     "optimist": "0.6.1",
     "path": "0.11.14",
     "safe-access": "0.1.0",
-    "sphere-node-sdk": "1.7.0",
-    "sphere-node-utils": "0.8.0",
+    "sphere-node-sdk": "^1.17.6",
+    "sphere-node-utils": "^0.9.1",
     "tmp": "0.0.25",
     "underscore": "1.8.3",
     "underscore-mixins": "0.1.4"


### PR DESCRIPTION
#### Summary
Fixes #10

#### Description
This PR bumps a version of a sphere SDK which has implemented a repeater for handling HTTP errors - https://github.com/sphereio/sphere-node-sdk/releases/tag/v1.17.0
